### PR TITLE
update/node-versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x, 24.x]
 
     env:
       CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
       - name: Install deps and build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.release.tag_name }}
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
       - name: Install deps and build
         run: npm ci && npm run build
       - uses: JasonEtco/build-and-tag-action@v2


### PR DESCRIPTION
This pull request updates the Node.js versions used in the CI and release workflows to ensure compatibility with the latest Node.js releases and improves the release workflow by upgrading the checkout action.

CI workflow updates:

* Updates the Node.js versions tested in the CI workflow to `22.x` and `24.x`, dropping `20.x` and adding `24.x` in `.github/workflows/ci.yml`.

Release workflow improvements:

* Upgrades the `actions/checkout` action from version 2 to version 4 and explicitly sets up Node.js 24.x using `actions/setup-node@v4` in `.github/workflows/release.yml`.